### PR TITLE
Fix: Handle DAMAGE_ALL enchantment name changes in 1.20.5 and 1.20.6 versions

### DIFF
--- a/src/main/java/xyz/geik/farmer/modules/voucher/helper/VoucherItem.java
+++ b/src/main/java/xyz/geik/farmer/modules/voucher/helper/VoucherItem.java
@@ -94,7 +94,7 @@ public class VoucherItem {
             meta.setLore(Voucher.getInstance().getLang().getTextList(path + ".lore"));
         meta.setDisplayName(Voucher.getInstance().getLang().getText(path + ".name"));
         if (Voucher.getInstance().getLang().getBoolean(path + ".glow")) {
-            if (Bukkit.getVersion().contains("1.21.")) {
+            if (Bukkit.getVersion().contains("1.21.") || Bukkit.getVersion().contains("1.20.6") || Bukkit.getVersion().contains("1.20.5") ) {
                 meta.addEnchant(Enchantment.SHARPNESS, 1, true);
             }
             else {


### PR DESCRIPTION
DAMAGE_ALL enchantment causes an error in Minecraft versions 1.20.5 and 1.20.6, as it was renamed to SHARPNESS. Previously, the code only handled 1.21+ versions.

Added support for SHARPNESS in versions 1.20.5, 1.20.6, and 1.21+, while maintaining compatibility with older versions using DAMAGE_ALL.

Tested
✅ 1.20.5
✅ 1.20.6